### PR TITLE
Update bupstash entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following list is sorted alphabetically:
  * [btar](http://viric.name/cgi-bin/btar/doc/trunk/doc/home.wiki/) review
  * [btbrk](https://github.com/digint/btrbk) review
  * [bup](https://github.com/bup/bup) review,dedup,incremental,error-correction
- * [bupstash](https://github.com/andrewchambers/bupstash) dedup,incremental,rust
+ * [bupstash](https://github.com/andrewchambers/bupstash) compression,dedup,encrypted,incremental,rust,authenticated
  * [burp](https://burp.grke.org/) review
  * [cedar-backup3](https://bitbucket.org/cedarsolutions/cedar-backup3/wiki/Home) review,python
  * [chop-backup/libchop](http://nongnu.org/libchop/) review


### PR DESCRIPTION
References:

- `compression,dedup,encrypted` https://bupstash.io/doc/guides/Getting%20Started.html
- `incremental` was already there, and it follows from dedup I think? Not sure why this is separate but I'll just leave it.
- `rust` https://github.com/andrewchambers/bupstash "Bupstash is written in a memory safe language to dramatically reduce the attack surface over the network" + GitHub language stats. Though there is also a lot of C code according to said language stats.
- `authenticated` https://github.com/andrewchambers/bupstash/blob/master/doc/technical_overview.md "We use libsodium cryptobox to encrypt each data chunk." -> https://doc.libsodium.org/public-key_cryptography/authenticated_encryption

For the order of the tags, I tried to look at other entries but it doesn't seem to be ordered in a particular way if I saw it correctly.